### PR TITLE
Added check to give 404 error for invalid HW requests, fixing 500 response

### DIFF
--- a/cse312_app.py
+++ b/cse312_app.py
@@ -4,6 +4,7 @@ from pymongo import MongoClient
 
 from flask import Flask, send_from_directory, render_template, make_response, request
 from flask_socketio import SocketIO
+import os
 
 app = Flask(__name__)
 socket_server = SocketIO(app)
@@ -67,6 +68,9 @@ def cse312():
 
 @app.get('/hw/<hw_url>')
 def hw(hw_url):
+    list_of_hws = os.listdir('templates/hw')
+    if hw_url not in list_of_hws:
+        return "Homework not found", 404
     resp = make_response(render_template('hw/' + str(hw_url)))
     resp.headers["X-Content-Type-Options"] = "nosniff"
     return resp


### PR DESCRIPTION
The server wasn't checking requests for HW URLs and  was giving  HTTP 500 error on invalid requests, instead of 404.
Example: On requesting [https://cse312.com/hw/hw1](https://cse312.com/hw/hw1) (correct link is [https://cse312.com/hw/hw1.html](https://cse312.com/hw/hw1.html)) I got "500 Internal Server Error" instead of a 404 Error.
<img width="1087" height="931" alt="image" src="https://github.com/user-attachments/assets/c8a0b731-5940-4e9b-b3f4-aac13ae21480" />
